### PR TITLE
Add module export for using tagin via import

### DIFF
--- a/js/tagin.js
+++ b/js/tagin.js
@@ -112,3 +112,5 @@ function tagin(el, option = {}) {
   }
   el.addEventListener('change', () => updateTag())
 }
+
+module.exports = tagin


### PR DESCRIPTION
Unfortunately I couldn't get gulp to compile on my system so I didn't update the version in `dist`.

But with this small change, I could easily

```
import * as tagin from "tagin/js/tagin";
```
