### PR TITLE
Refactor Tagin as a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Demo: [https://tagin.netlify.app/](https://tagin.netlify.app/)
 - Custom separators
 - Enable/disable duplicates
 - Custom transform
-- Supports bootstrap validation style
+- Supports Bootstrap validation style
 - Fast
 - Small
-- No depedencies
+- No dependencies
 
 
 ## Installation
@@ -30,7 +30,7 @@ Install from cdn:
 
 ## Usage/Examples
 
-Place `css` between `<head></head>` tag:
+Place `css` between `<head></head>` tags:
 ```html
 <head>
     <link rel="stylesheet" href="https://unpkg.com/tagin/dist/css/tagin.min.css">
@@ -49,7 +49,7 @@ In your script file, import Tagin (Change location according to your path):
 import Tagin from "./tagin.js";
 ```
 
-#### 1. Basic Usage (No `data-options` attribute needed)
+#### 1. Basic Usage (No `data-options` attribute needed):
 ```html
 <input type="text" name="tags" class="form-control tagin" value="red,green,blue">
 ```
@@ -68,13 +68,13 @@ tagin.getTags(); // Return tags as array ["red", "green", "blue", "yellow"]
 ```
 
 #### 2. Using Placeholder
-Set placeholder using `data-placeholder` attribute.
+Using `data-placeholder` attribute:
 ```html
 <input type="text" name="tags" class="form-control tagin" value="red,green,blue" data-placeholder="Add a color... (then press comma)">
-
-<script>
-  tagin(document.querySelector('.tagin'))
-</script>
+```
+Or using module option:
+```js
+tagin = new Tagin(document.querySelector(".tagin"), {placeholder: "Add a color... (then press comma)"});
 ```
 
 #### 3. Using Custom Separator

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Tagin
 
-Simple tag input for Bootstrap. Support bootstrap v4 and v5.
+Simple tag input for Bootstrap. Supports bootstrap v4 and v5.
 
 Demo: [https://tagin.netlify.app/](https://tagin.netlify.app/)
 
 ## Features
 
-- Custom separator
-- Enable / disable duplicates
+- Custom separators
+- Enable/disable duplicates
 - Custom transform
-- Support bootstrap validation style
+- Supports bootstrap validation style
 - Fast
 - Small
 - No depedencies
@@ -17,41 +17,54 @@ Demo: [https://tagin.netlify.app/](https://tagin.netlify.app/)
 
 ## Installation
 
-Install tagin with npm
+Install tagin with npm:
 ```bash
 npm install tagin
 ```
 
-Install from cdn
+Install from cdn:
 ```html
 <link rel="stylesheet" href="https://unpkg.com/tagin/dist/css/tagin.min.css">
-<script src="https://unpkg.com/tagin/dist/js/tagin.min.js"></script>
+<script src="https://unpkg.com/tagin/dist/js/tagin.min.js" type="module"></script>
 ```
 
 ## Usage/Examples
 
-Place `css` between `<head></head>` tag
+Place `css` between `<head></head>` tag:
 ```html
 <head>
     <link rel="stylesheet" href="https://unpkg.com/tagin/dist/css/tagin.min.css">
 </head>
 ```
 
-Place `js` before `</body>` tag
+Place `js` before `</body>` tag:
 ```html
 <body>
     ...
-    <script src="https://unpkg.com/tagin/dist/js/tagin.min.js"></script>
+    <script src="https://unpkg.com/tagin/dist/js/tagin.min.js" type="module"></script>
 </body>
+```
+In your script file, import Tagin (Change location according to your path):
+```js
+import Tagin from "./tagin.js";
 ```
 
 #### 1. Basic Usage (No `data-options` attribute needed)
 ```html
 <input type="text" name="tags" class="form-control tagin" value="red,green,blue">
+```
+```js
+var options = {
+    separator: ',', // default: ','
+    duplicate: false, // default: false
+    enter: true, // default: false
+    transform: input => input.toUpperCase(), // default: input => input
+    placeholder: 'Add a group...' // default: ''
+};
+tagin = new Tagin(document.querySelector(".tagin"), options);
 
-<script>
-  tagin(document.querySelector('.tagin'))
-</script>
+tagin.addTag(true, "yellow"); // Add tag "yellow"
+tagin.getTags(); // Return tags as array ["red", "green", "blue", "yellow"]
 ```
 
 #### 2. Using Placeholder
@@ -65,42 +78,44 @@ Set placeholder using `data-placeholder` attribute.
 ```
 
 #### 3. Using Custom Separator
-Set separator using `data-separator` attribute. Example tags using 'space' separator.
+Example tags with 'space' separator.
+Using `data-separator` attribute:
 ```html
 <input type="text" name="tags" class="form-control tagin" data-separator=" " value="red green blue">
-
-<script>
-  tagin(document.querySelector('.tagin'))
-</script>
+```
+Or using module option:
+```js
+tagin = new Tagin(document.querySelector(".tagin"), {separator: " "});
 ```
 
 #### 4. Allow Duplicates
 Add `data-duplicate="true"` to remove duplicates validation.
 ```html
 <input type="text" name="tags" class="form-control tagin" data-duplicate="true" value="html,html,css,css,js,js">
-
-<script>
-  tagin(document.querySelector('.tagin'))
-</script>
+```
+Or using module option:
+```js
+tagin = new Tagin(document.querySelector(".tagin"), {duplicate: true});
 ```
 
 #### 5. Transform Tags
 Sometimes we need to transform tags.
-Example transform using `toUpperCase`.
+Example tags with `toUpperCase()`.
+Using  `data-transform` attribute:
 ```html
 <input type="text" name="tags" class="form-control tagin" data-transform="input => input.toUpperCase()" value="HTML,CSS">
-
-<script>
-  tagin(document.querySelector('.tagin'))
-</script>
+```
+Or using module option:
+```js
+tagin = new Tagin(document.querySelector(".tagin"), {transform: input => input.toUpperCase()});
 ```
 
 #### 6. Force add on enter
-Add `data-enter="true"` to force add tag when enter key is pressed.
+Add `data-enter="true"` to force adding tag when enter key is pressed.
 ```html
 <input type="text" name="tags" class="form-control tagin" data-enter="true" value="red,green,blue" data-placeholder="Add a color... (then press comma or enter)">
-
-<script>
-  tagin(document.querySelector('.tagin'))
-</script>
+```
+Or using module option:
+```js
+tagin = new Tagin(document.querySelector(".tagin"), {enter: true});
 ```

--- a/dist/js/tagin.js
+++ b/dist/js/tagin.js
@@ -1,122 +1,164 @@
-function tagin(el, option = {}) {
-  const classElement = 'tagin'
-  const classWrapper = 'tagin-wrapper'
-  const classTag = 'tagin-tag'
-  const classRemove = 'tagin-tag-remove'
-  const classInput = 'tagin-input'
-  const classInputHidden = 'tagin-input-hidden'
-  const defaultSeparator = ','
-  const defaultDuplicate = 'false'
-  const defaultEnter = 'false'
-  const defaultTransform = input => input
-  const defaultPlaceholder = ''
-  const separator = el.dataset.separator || option.separator || defaultSeparator
-  const duplicate = el.dataset.duplicate || option.duplicate || defaultDuplicate
-  const enter = el.dataset.enter || option.enter || defaultEnter
-  const transform = eval(el.dataset.transform) || option.transform || defaultTransform
-  const placeholder = el.dataset.placeholder || option.placeholder || defaultPlaceholder
+export default class Tagin {
+    /**
+    * Create a new Tagin instance.
+    *
+    * @param el - Element anchor.
+    * @param option - Customization options.
+    *
+    * @example
+    * ```js
+    * var options = {
+    *     separator: ',', // default: ','
+    *     duplicate: false, // default: false
+    *     enter: true, // default: false
+    *     transform: input => input.toUpperCase(), // default: input => input
+    *     placeholder: 'Enter tags...' // default: ''
+    * };
+    * var tagin = new Tagin(document.getElementById('tagin'), options);
+    * ```
+    */
+    constructor(el, option = {}) {
+        const classElement = 'tagin';
+        const classWrapper = 'tagin-wrapper';
+        const classTag = 'tagin-tag';
+        const classRemove = 'tagin-tag-remove';
+        const classInput = 'tagin-input';
+        const classInputHidden = 'tagin-input-hidden';
+        const defaultSeparator = ',';
+        const defaultDuplicate = 'false';
+        const defaultEnter = 'false';
+        const defaultTransform = input => input;
+        const defaultPlaceholder = '';
+        const separator = el.dataset.separator || option.separator || defaultSeparator;
+        const duplicate = el.dataset.duplicate || option.duplicate || defaultDuplicate;
+        const enter = el.dataset.enter || option.enter || defaultEnter;
+        const transform = eval(el.dataset.transform) || option.transform || defaultTransform;
+        const placeholder = el.dataset.placeholder || option.placeholder || defaultPlaceholder;
 
-  const templateTag = value => `<span class="${classTag}">${value}<span class="${classRemove}"></span></span>`
+        const templateTag = value => `<span class="${classTag}">${value}<span class="${classRemove}"></span></span>`;
 
-  const getValue = () => el.value
-  const getValues = () => getValue().split(separator)
+        const getValue = () => el.value;
+        const getValues = () => getValue().split(separator); (function () {
+            const className = classWrapper + ' ' + el.className.replace(classElement, '').replace("setting_input", '').trim();
+            const tags = getValue().trim() === '' ? '' : getValues().map(templateTag).join('');
+            const template = `<div class="${className}">${tags}<input type="text" class="${classInput}" placeholder="${placeholder}"></div>`;
+            el.insertAdjacentHTML('afterend', template); // insert template after element
+        })();
 
-  // Create
-  ; (function () {
-    const className = classWrapper + ' ' + el.className.replace(classElement, '').trim()
-    const tags = getValue().trim() === '' ? '' : getValues().map(templateTag).join('')
-    const template = `<div class="${className}">${tags}<input type="text" class="${classInput}" placeholder="${placeholder}"></div>`
-    el.insertAdjacentHTML('afterend', template) // insert template after element
-  })()
+        const wrapper = el.nextElementSibling;
+        const input = wrapper.getElementsByClassName(classInput)[0];
+        const getTags = () => [...wrapper.getElementsByClassName(classTag)].map(tag => tag.textContent);
+        const getTag = () => getTags().join(separator);
 
-  const wrapper = el.nextElementSibling
-  const input = wrapper.getElementsByClassName(classInput)[0]
-  const getTags = () => [...wrapper.getElementsByClassName(classTag)].map(tag => tag.textContent)
-  const getTag = () => getTags().join(separator)
+        const updateValue = () => { el.value = getTag(); el.dispatchEvent(new Event('change')) };
 
-  const updateValue = () => { el.value = getTag(); el.dispatchEvent(new Event('change')) }
+        // Focus to input
+        wrapper.addEventListener('click', () => input.focus());
 
-  // Focus to input
-  wrapper.addEventListener('click', () => input.focus())
+        // Toggle focus class
+        input.addEventListener('focus', () => wrapper.classList.add('focus'));
+        input.addEventListener('blur', () => wrapper.classList.remove('focus'));
 
-  // Toggle focus class
-  input.addEventListener('focus', () => wrapper.classList.add('focus'))
-  input.addEventListener('blur', () => wrapper.classList.remove('focus'))
+        // Remove by click
+        document.addEventListener('click', e => {
+            if (e.target.closest('.' + classRemove)) {
+                e.target.closest('.' + classRemove).parentNode.remove();
+                updateValue();
+            }
+        });
 
-  // Remove by click
-  document.addEventListener('click', e => {
-    if (e.target.closest('.' + classRemove)) {
-      e.target.closest('.' + classRemove).parentNode.remove()
-      updateValue()
-    }
-  })
+        // Remove with backspace
+        input.addEventListener('keydown', e => {
+            if (input.value === '' && e.keyCode === 8 && wrapper.getElementsByClassName(classTag).length) {
+                wrapper.querySelector('.' + classTag + ':last-of-type').remove();
+                updateValue();
+            }
+            if (input.value !== '' && e.keyCode === 13 && (enter === "true" || enter === true)) {
+                this.addTag(true, transform(input.value.trim()));
+                e.preventDefault();
+            }
+        });
 
-  // Remove with backspace
-  input.addEventListener('keydown', e => {
-    if (input.value === '' && e.keyCode === 8 && wrapper.getElementsByClassName(classTag).length) {
-      wrapper.querySelector('.' + classTag + ':last-of-type').remove()
-      updateValue()
-    }
-    if (input.value !== '' && e.keyCode === 13 && enter === 'true') {
-      addTag(true)
-      autowidth()
-      e.preventDefault()
-    }
-  })
+        // Adding tag
+        input.addEventListener('input', () => {
+            this.addTag(false, transform(input.value.trim()));
+        })
+        input.addEventListener('blur', () => {
+            this.addTag(true, transform(input.value.trim()));
+        })
 
-  // Adding tag
-  input.addEventListener('input', () => {
-    addTag()
-    autowidth()
-  })
-  input.addEventListener('blur', () => {
-    addTag(true)
-    autowidth()
-  })
-  autowidth()
-
-  function autowidth() {
-    const fakeEl = document.createElement('div')
-    fakeEl.classList.add(classInput, classInputHidden)
-    const string = input.value || input.getAttribute('placeholder') || ''
-    fakeEl.innerHTML = string.replace(/ /g, '&nbsp;')
-    document.body.appendChild(fakeEl)
-    input.style.setProperty('width', Math.ceil(window.getComputedStyle(fakeEl).width.replace('px', '')) + 1 + 'px')
-    fakeEl.remove()
-  }
-  function addTag(force = false) {
-    const value = transform(input.value.trim())
-    if (value === '') { input.value = '' }
-    if (input.value.includes(separator) || (force && input.value != '')) {
-      value.split(separator).filter(i => i != '').forEach(val => {
-        if (getTags().includes(val) && duplicate === 'false') {
-          alertExist(val)
-        } else {
-          input.insertAdjacentHTML('beforebegin', templateTag(val))
-          updateValue()
+        function autowidth() {
+            const fakeEl = document.createElement('div');
+            fakeEl.classList.add(classInput, classInputHidden);
+            const string = input.value || input.getAttribute('placeholder') || '';
+            fakeEl.innerHTML = string.replace(/ /g, '&nbsp;');
+            document.body.appendChild(fakeEl);
+            input.style.setProperty('width', Math.ceil(window.getComputedStyle(fakeEl).width.replace('px', '')) + 1 + 'px');
+            fakeEl.remove();
         }
-      })
-      input.value = ''
-      input.removeAttribute('style')
+
+        /**
+        * Adds a tag or multiple tags.
+        *
+        * @param force - Add tag even without separator (bool)
+        * @param tagName - The tag name(s) to add (string)
+        *
+        * @example
+        * Multiple tags should be a comma separated string:
+        * ```js
+        * this.addTag(true, 'NewTag')
+        * this.addTag(false, 'OneTag, TwoTag, ThreeTag')
+        * let tagArray = ['OneTag', 'TwoTag', 'ThreeTag']
+        * this.addTag(false, tagArray.join(', '))
+        * ```
+        */
+        this.addTag = (force = false, tagName = '') => {
+            if (tagName === '') { input.value = ''; }
+            if (tagName.includes(separator) || (force && tagName != '')) {
+                tagName.split(separator).filter(i => i != '').forEach(val => {
+                    if (getTags().includes(val) && (duplicate === 'false' || duplicate === false)) {
+                        alertExist(val);
+                    } else {
+                        input.insertAdjacentHTML('beforebegin', templateTag(val));
+                        updateValue();
+                    }
+                })
+                input.value = '';
+                input.removeAttribute('style');
+            }
+            autowidth();
+        }
+
+        /**
+        * Returns an array of tags.
+        *
+        * @returns array
+        */
+        this.getTags = () => {
+            return getTags().map(s => s.trim());;
+        };
+
+        function alertExist(value) {
+            for (const el of wrapper.getElementsByClassName(classTag)) {
+                if (el.textContent === value) {
+                    el.style.transform = 'scale(1.09)';
+                    setTimeout(() => { el.removeAttribute('style') }, 150);
+                }
+            }
+        }
+
+        function updateTag() {
+            if (getValue() !== getTag()) {
+                [...wrapper.getElementsByClassName(classTag)].map(tag => tag.remove());
+                getValue().trim() !== '' && input.insertAdjacentHTML('beforebegin', getValues().map(templateTag).join(''));
+            }
+        }
+
+        autowidth();
+        el.addEventListener('change', () => updateTag());
     }
-  }
-  function alertExist(value) {
-    for (const el of wrapper.getElementsByClassName(classTag)) {
-      if (el.textContent === value) {
-        el.style.transform = 'scale(1.09)'
-        setTimeout(() => { el.removeAttribute('style') }, 150)
-      }
-    }
-  }
-  function updateTag() {
-    if (getValue() !== getTag()) {
-      [...wrapper.getElementsByClassName(classTag)].map(tag => tag.remove())
-      getValue().trim() !== '' && input.insertAdjacentHTML('beforebegin', getValues().map(templateTag).join(''))
-    }
-  }
-  el.addEventListener('change', () => updateTag())
 }
 
 if (typeof exports === 'object' && typeof module !== 'undefined') {
-  module.exports = tagin
+    module.exports = Tagin;
 }


### PR DESCRIPTION
Allows to easily import the module and use functions such as `.addTag()` and `.getTags()` outside the class itself.
Also implements #10.

This eliminates the ugly ways of adding and getting tags:
```js
// Getting tags:
// Old way
input.value.split(',');

// New way
tagin = new Tagin(document.querySelector(".tagin"));
tagin.getTags();


// Adding Tags:
// Old way
const target = document.querySelector('.tagin');
target.value = 'red,green,blue';
target.dispatchEvent(new Event('change'));

// New way
tagin = new Tagin(document.querySelector(".tagin"));
tagin.addTag(False, 'red,green,blue');
```

I updated the `README.md` to reflect the changes.